### PR TITLE
curveID can now represent multiple columns in userGcMeta

### DIFF
--- a/tests/testthat/test-1-module_2-multi-curveID.R
+++ b/tests/testthat/test-1-module_2-multi-curveID.R
@@ -1,0 +1,84 @@
+
+if (!testthat::is_testing()) source(testthat::test_path("setup.R"))
+
+test_that("Module runs with multiple curveID", {
+
+  ## Run simInit and spades ----
+
+  # Set up project
+  projectName <- "2-multi-curveID"
+
+  simInitInput <- SpaDES.project::setupProject(
+
+    modules = "CBM_vol2biomass_SK",
+    paths   = list(
+      projectPath = spadesTestPaths$projectPath,
+      modulePath  = spadesTestPaths$modulePath,
+      packagePath = spadesTestPaths$packagePath,
+      inputPath   = spadesTestPaths$inputPath,
+      cachePath   = spadesTestPaths$cachePath,
+      outputPath  = file.path(spadesTestPaths$temp$outputs, projectName)
+    ),
+
+    curveID = c("species", "moisture"),
+
+    userGcSPU = data.frame(
+      spatial_unit_id = 28,
+      species         = "Balsam Fir",
+      moisture        = 50
+    ),
+    userGcMeta = data.frame(
+      curveID     = 22,
+      species     = "Balsam Fir",
+      moisture    = 50
+    ),
+    userGcM3 = data.frame(
+      curveID     = 22,
+      Age         = 0:250,
+      MerchVolume = 0:250
+    )
+  )
+
+  # Run simInit
+  simTestInit <- SpaDES.core::simInit2(simInitInput)
+
+  expect_s4_class(simTestInit, "simList")
+
+  # Run spades
+  simTest <- SpaDES.core::spades(simTestInit)
+
+  expect_s4_class(simTest, "simList")
+
+
+  ## Check outputs 'volCurves' ----
+
+  expect_true(!is.null(simTest$volCurves))
+  expect_true(inherits(simTest$volCurves, "ggplot"))
+
+
+  ## Check output 'cumPoolsClean' ----
+
+  expect_true(!is.null(simTest$cPoolsClean))
+  expect_true(inherits(simTest$cPoolsClean, "data.table"))
+
+  expect_true("28_Balsam Fir_50" %in% simTest$cPoolsClean$gcids)
+
+
+  ## Check output 'gcMeta' ---
+
+  expect_true(!is.null(simTest$gcMeta))
+  expect_true(inherits(simTest$gcMeta, "data.table"))
+
+  expect_true("28_Balsam Fir_50" %in% simTest$gcMeta$gcids)
+
+
+  ## Check output 'growth_increments' ----
+
+  expect_true(!is.null(simTest$growth_increments))
+  expect_true(inherits(simTest$growth_increments, "data.table"))
+
+  expect_true("28_Balsam Fir_50" %in% simTest$growth_increments$gcids)
+
+})
+
+


### PR DESCRIPTION
Turns out [this](https://github.com/PredictiveEcology/CBMutils/pull/63#issuecomment-3250158175) wasn't too difficult to implement. I added a test that gives a simple example of this.

I did make one change here that I think is better: Before, all 3 input tables `userGcMeta`, `userGcM3`, and `userGcSPU` had to have all columns in `sim$curveID`. In this update, `userGcMeta` and `userGcM3` both have to have matching 'curveID' columns, but `sim$curveID` can be any number of columns, as long as they match in `userGcMeta` and `userGcSPU`. This makes it so that `userGcM3` (a very large table) will never need to have all the same columns as `userGcMeta`; these tables will remain linked by the single column 'curveID'.

An example of what this could look like (pulled from the new test). `userGcSPU` no longer needs to have the 'curveID' column:

```
  SpaDES.project::setupProject(

    modules = "CBM_vol2biomass_SK",
    paths   = list(
      projectPath = spadesTestPaths$projectPath,
      modulePath  = spadesTestPaths$modulePath,
      packagePath = spadesTestPaths$packagePath,
      inputPath   = spadesTestPaths$inputPath,
      cachePath   = spadesTestPaths$cachePath,
      outputPath  = file.path(spadesTestPaths$temp$outputs, projectName)
    ),

    curveID = c("species", "moisture"),

    # Define growth curves and spatial unit combos found in the study area
    userGcSPU = data.frame(
      spatial_unit_id = 28,
      species         = "Balsam Fir",
      moisture        = 50
    ),

    # Growth curve metadata
    userGcMeta = data.frame(
      curveID     = 22,
      species     = "Balsam Fir",
      moisture    = 50
    ),

    # Growth curve columns
    userGcM3 = data.frame(
      curveID     = 22,
      Age         = 0:250,
      MerchVolume = 0:250
    )
  )
```